### PR TITLE
Update plugin.py to fix some uninitialized object members 

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -70,7 +70,9 @@ class Zone:
 
     def checkDevices(self):
         iconName = 'Yamaha'
-        iconID = Images[iconName].ID
+
+        if iconName in Images:
+            iconID = Images[iconName].ID
 
         inputControlOptions = {
             "LevelActions"   : "",
@@ -325,7 +327,8 @@ class BasePlugin:
         if iconName not in Images:
             Domoticz.Image('icons.zip').Create()
 
-        iconID = Images[iconName].ID
+        if iconName in Images:
+            iconID = Images[iconName].ID
 
         self.zones = []
 


### PR DESCRIPTION
Make sure that iconName is in the list before using it. This will protect the plugin to crash in the onStart and init section and not initialize the Zone member